### PR TITLE
Support click on groups

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "name": "__MSG_appName__",
     "short_name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
-    "version": "1.0.2",
+    "version": "1.0.4",
     "author": "Rung <developer@rung.com.br>",
     "default_locale": "en",
     "icons": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
-    "webpack": "webpack -w"
+    "webpack": "webpack -w",
+    "release": "rm -rf public && webpack -p && zip -r rung.zip public"
   },
   "keywords": [
     "BuckleScript"

--- a/src/chrome/request.re
+++ b/src/chrome/request.re
@@ -1,14 +1,14 @@
-let request = (path) => Js.Promise.(
+let request = (~method_=Fetch.Get, path) => Js.Promise.(
     Fetch.fetchWithInit(
-        "http://app.rung.com.br/api" ++ path,
-        Fetch.RequestInit.make(~credentials=Include, ()))
+        "https://app.rung.com.br/api" ++ path,
+        Fetch.RequestInit.make(~credentials=Include, ~method_, ()))
     |> then_((response) => Fetch.Response.ok(response)
         ? Fetch.Response.text(response)
         : Js.Exn.raiseError("")));
 
 let login = (email, password) => Js.Promise.(
     Fetch.fetchWithInit(
-        "http://app.rung.com.br/api/login/",
+        "https://app.rung.com.br/api/login/",
         Fetch.RequestInit.make(
             ~credentials=Include,
             ~headers=Fetch.HeadersInit.make({"content-type": "application/json"}),

--- a/src/components/Notification.re
+++ b/src/components/Notification.re
@@ -1,7 +1,7 @@
 let component = ReasonReact.statelessComponent("Notification");
 
 [@bs.new]
-external now : unit => Js.Date.t = "Date";
+external now : string => Js.Date.t = "Date";
 
 module DateFns = {
     [@bs.module "date-fns"]
@@ -11,13 +11,13 @@ module DateFns = {
 let t = key => Chrome.(chrome##i18n##getMessage(key));
 let show = ReasonReact.stringToElement;
 
-let make = (~text, ~color, ~icon, ~onClick, ~read, _children) => {
+let make = (~text, ~color, ~icon, ~onClick, ~read, ~date, _children) => {
     ...component,
-    render: (self) =>
+    render: (_self) =>
         <li className=("collection-item avatar notification " ++ (read ? "" : "unread")) onClick>
             <i className=("material-icons circle " ++ color)>(ReasonReact.stringToElement(icon))</i>
             <h6>(ReasonReact.stringToElement(text))</h6>
-            <p>(ReasonReact.stringToElement(DateFns.distanceInWordsToNow(now())))</p>
+            <p>(ReasonReact.stringToElement(DateFns.distanceInWordsToNow(now(date))))</p>
         </li>
 }
 

--- a/src/components/Notification.re
+++ b/src/components/Notification.re
@@ -11,16 +11,10 @@ module DateFns = {
 let t = key => Chrome.(chrome##i18n##getMessage(key));
 let show = ReasonReact.stringToElement;
 
-let handleClick = (task) =>
-    switch (Js.Nullable.to_opt(task)) {
-    | Some(id) => Chrome.(chrome##tabs##create({"url": "https://app.rung.com.br/i/" ++ id}))
-    | None => ()
-    };
-
-let make = (~text, ~color, ~icon, ~task, _children) => {
+let make = (~text, ~color, ~icon, ~onClick, ~read, _children) => {
     ...component,
     render: (self) =>
-        <li className="collection-item avatar notification" onClick=(self.handle((_event, _self) => handleClick(task)))>
+        <li className=("collection-item avatar notification " ++ (read ? "" : "unread")) onClick>
             <i className=("material-icons circle " ++ color)>(ReasonReact.stringToElement(icon))</i>
             <h6>(ReasonReact.stringToElement(text))</h6>
             <p>(ReasonReact.stringToElement(DateFns.distanceInWordsToNow(now())))</p>

--- a/src/screens/NotificationList.re
+++ b/src/screens/NotificationList.re
@@ -40,8 +40,13 @@ let reducer = (action, state) =>
                 let validNotifications = notifications
                 |> Js.Array.filter((notification) => String.lowercase(notification##_type) == notification##_type);
 
-                Chrome.(chrome##browserAction##setBadgeText(
-                    {"text": string_of_int(Array.length(validNotifications))}));
+                Chrome.(
+                    chrome##browserAction##setBadgeText({
+                        "text": validNotifications
+                        |> Js.Array.filter((notification) => Js.Nullable.test(notification##readDate))
+                        |> Array.length
+                        |> string_of_int
+                    }));
                 self.reduce((_) => SetNotifications(validNotifications), ())
             }
             |> resolve))
@@ -138,11 +143,12 @@ let make = (_children) => {
                         text
                         color
                         icon
-                        onClick=((_) => reduce((_) => ReadNotification(notification##id), ()))
-                        read=(switch (Js.Nullable.to_opt(notification##readDate)) {
-                        | Some(_) => true
-                        | None => false
+                        onClick=((_) => {
+                            if (Js.Nullable.test(notification##readDate)) {
+                                reduce((_) => ReadNotification(notification##id), ())
+                            }
                         })
+                        read=(!Js.Nullable.test(notification##readDate))
                     />
                 })
                 |> ReasonReact.arrayToElement

--- a/src/screens/NotificationList.re
+++ b/src/screens/NotificationList.re
@@ -6,7 +6,7 @@ type notification = {.
     "task": Js.Nullable.t(string),
     "readDate": Js.Nullable.t(string),
     "name": string,
-    "values": option(array(string))
+    "values": Js.Nullable.t(array(string))
 };
 
 type action =
@@ -83,7 +83,7 @@ let t = key => Chrome.(chrome##i18n##getMessage(key));
 let replace = Js.String.replace;
 
 let countAlerts = notification =>
-    switch (notification##values) {
+    switch (Js.Nullable.to_opt(notification##values)) {
     | Some(result) => Array.length(result)
     | None => 0
     };

--- a/src/screens/NotificationList.re
+++ b/src/screens/NotificationList.re
@@ -171,6 +171,7 @@ let make = (_children) => {
 
                             handle((_event, _self) => handleClickNotification(notification), ())
                         })
+                        date=(notification##date)
                         read=(!Js.Nullable.test(notification##readDate))
                     />
                 })

--- a/src/screens/NotificationList.re
+++ b/src/screens/NotificationList.re
@@ -125,7 +125,7 @@ let handleClickNotification = (notification) =>
             |> Js.Array.joinWith(";")
             |> openTab("n"))
         |> ignore
-    | "permissions-updated" | "alerts-manually-deleted" | "alerts-deleted" => ()
+    | "permissions-updated" | "alert-manually-deleted" | "alerts-deleted" => ()
     | "alert-comment" | "alert-follow" | "alert-unfollow" | "task-created" =>
         notification##dispatcher >>= ([@bs] (dispatcher) => openTab("i", dispatcher))
         |> ignore


### PR DESCRIPTION
This pull-request adds a lot of improvements and fixes.

### Improvements
- Tell read from unread notifications
- Read notification on click on it
- Clicking in the notification popup will close it
- Clicking on a notification with several values will highlight its values
- Clicking on a notification with `task` or `dispatcher` will consider that as a fallback 

### Bugfixes
- The notification date was always "1 minute ago", now it is real
- Fix notification count (unread)
- Use `https`
- Use `'a Js.nullable` on error-prone fields because `'a option` doesn't convert things automagically

> Random picture of an alpaca to make you happy

![Alpaca](https://blog.zizoo.com/wp-content/uploads/2015/03/5723682302_60aaec46e9_b.jpg)